### PR TITLE
Fix test

### DIFF
--- a/libp2p/netMessenger_test.go
+++ b/libp2p/netMessenger_test.go
@@ -1788,6 +1788,7 @@ func TestNetworkMessenger_GetConnectedPeersInfo(t *testing.T) {
 	}
 	messenger, _ := libp2p.NewMockMessenger(createMockNetworkArgs(), netw)
 	closeMessengers(messenger)
+	selfID := messenger.ID()
 
 	messenger.SetHost(&mock.ConnectableHostStub{
 		NetworkCalled: func() network.Network {
@@ -1799,6 +1800,9 @@ func TestNetworkMessenger_GetConnectedPeersInfo(t *testing.T) {
 					return make([]network.Conn, 0)
 				},
 			}
+		},
+		IDCalled: func() peer.ID {
+			return peer.ID(selfID)
 		},
 	})
 	selfShardID := uint32(0)


### PR DESCRIPTION
Because now pid is part of connectionsHandler ctor and in tests the host is set after creation of connectionsHandler, self id is the mocked one, leading to invalid test which somehow randomly passes.